### PR TITLE
Fix inaccuracies in setup-dev-env.md

### DIFF
--- a/docs/setup-dev-env.md
+++ b/docs/setup-dev-env.md
@@ -25,14 +25,15 @@ Before proceeding, ensure you have:
 - For Android development: Java JDK, Android SDK, emulator or physical device  
 - For iOS targets (on macOS): Xcode + command line tools  
 
-> Microsoft’s official .NET MAUI installation guidance is useful: see “Install Visual Studio / .NET / workloads” sections. ([learn.microsoft.com](https://learn.microsoft.com/en-us/dotnet/maui/get-started/installation?view=net-maui-9.0&utm_source=chatgpt.com))  
-> The .NET MAUI extension for VS Code adds debugging, target switching, etc. ([marketplace.visualstudio.com](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-maui&utm_source=chatgpt.com))  
+> Microsoft’s official .NET MAUI installation guidance is useful: see “Install Visual Studio / .NET / workloads” sections. ([learn.microsoft.com](https://learn.microsoft.com/en-us/dotnet/maui/get-started/installation?view=net-maui-9.0))  
+> The .NET MAUI extension for VS Code adds debugging, target switching, etc. ([marketplace.visualstudio.com](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-maui))  
 
 ---
 
 ## 1. Install .NET SDK & Workloads
 
-1. Download and install the latest **.NET SDK** from [https://dotnet.microsoft.com/en-us/download](https://dotnet.microsoft.com/en-us/download).  
+1. Download and install the **.NET 9 SDK** from [https://dotnet.microsoft.com/en-us/download](https://dotnet.microsoft.com/en-us/download).  
+   > **Note:** This repository includes a `global.json` that pins the SDK to version **9.0.304**. Make sure you have this version (or a compatible 9.x patch) installed, or the build may fail.
 2. Verify by running:
    ```bash
    dotnet --version
@@ -65,7 +66,10 @@ dotnet new install Microsoft.Maui.Templates
    git clone https://github.com/unifiedfx/DeviceFX.NFC.git
    cd DeviceFX.NFC
    ```
-2. Confirm that the solution file `DeviceFX.NfcApp.sln` exists.  
+2. Confirm that the solution files exist. The repository contains:
+   - `DeviceFX.NfcApp.sln` — the main MAUI app
+   - `DeviceFX.Function.sln` — Azure Functions project
+   - `DeviceFX.Proxy.CDA.sln` — CDA proxy project
 3. Launch VS Code at the repository root:
    ```bash
    code .
@@ -77,12 +81,12 @@ dotnet new install Microsoft.Maui.Templates
 
 In VS Code, install:
 
-- **C# Dev Kit** (required) ([code.visualstudio.com](https://code.visualstudio.com/docs/csharp/get-started?utm_source=chatgpt.com))  
-- **.NET MAUI** extension (which depends on C# Dev Kit) ([marketplace.visualstudio.com](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-maui&utm_source=chatgpt.com))  
+- **C# Dev Kit** (required) ([code.visualstudio.com](https://code.visualstudio.com/docs/csharp/get-started))  
+- **.NET MAUI** extension (which depends on C# Dev Kit) ([marketplace.visualstudio.com](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-maui))
 
 These provide tooling support: build, debugging, project explorer, etc.
 
-After installation, you may see a .NET MAUI “walkthrough” or setup prompts. Follow them to connect your Microsoft account (for Dev Kit) and configure environment. ([learn.microsoft.com](https://learn.microsoft.com/en-us/dotnet/maui/get-started/installation?view=net-maui-9.0&utm_source=chatgpt.com))
+After installation, you may see a .NET MAUI “walkthrough” or setup prompts. Follow them to connect your Microsoft account (for Dev Kit) and configure environment. ([learn.microsoft.com](https://learn.microsoft.com/en-us/dotnet/maui/get-started/installation?view=net-maui-9.0))
 
 ---
 
@@ -104,10 +108,14 @@ To build or debug on Android:
 
 5. Use the MAUI target `InstallAndroidDependencies` if needed:
    ```bash
-   dotnet build -t:InstallAndroidDependencies -f:net8.0-android      -p:AndroidSdkDirectory="$ANDROID_HOME"      -p:JavaSdkDirectory="$JAVA_HOME"      -p:AcceptAndroidSDKLicenses=true
+   dotnet build -t:InstallAndroidDependencies \
+     -f:net9.0-android \
+     -p:AndroidSdkDirectory="$ANDROID_HOME" \
+     -p:JavaSdkDirectory="$JAVA_HOME" \
+     -p:AcceptAndroidSDKLicenses=true
    ```
 
-6. In VS Code, you may run the command palette (Ctrl+Shift+P / Cmd+Shift+P) → `​.NET MAUI: Configure Android` → and set / refresh the Android environment. ([learn.microsoft.com](https://learn.microsoft.com/en-us/dotnet/maui/get-started/installation?view=net-maui-9.0&utm_source=chatgpt.com))  
+6. In VS Code, you may run the command palette (Ctrl+Shift+P / Cmd+Shift+P) → `​.NET MAUI: Configure Android` → and set / refresh the Android environment. ([learn.microsoft.com](https://learn.microsoft.com/en-us/dotnet/maui/get-started/installation?view=net-maui-9.0))  
 
 ---
 
@@ -122,13 +130,13 @@ If you're on macOS and want to build for iOS:
    ```
 3. Accept license agreements, open Xcode at least once.  
 4. Ensure simulator runtimes are installed (Xcode → Preferences → Components).  
-5. In VS Code, run `​.NET MAUI: Configure Apple` → Refresh Apple environment. ([learn.microsoft.com](https://learn.microsoft.com/en-us/dotnet/maui/get-started/installation?view=net-maui-9.0&utm_source=chatgpt.com))  
+5. In VS Code, run `​.NET MAUI: Configure Apple` → Refresh Apple environment. ([learn.microsoft.com](https://learn.microsoft.com/en-us/dotnet/maui/get-started/installation?view=net-maui-9.0))  
 
 ---
 
 ## 6. Select Startup Project & Debug Target in VS Code
 
-- In the status bar, click the `{ }` icon next to file language to select the debugging target (e.g. Android emulator, iOS Simulator, etc.). ([marketplace.visualstudio.com](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-maui&utm_source=chatgpt.com))  
+- In the status bar, click the `{ }` icon next to file language to select the debugging target (e.g. Android emulator, iOS Simulator, etc.). ([marketplace.visualstudio.com](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-maui))  
 - Ensure the correct **startup project** (in the solution) is selected (e.g. the MAUI app project).  
 - Use `F5` or the Run toolbar button to build & launch.
 
@@ -140,13 +148,13 @@ You can also build and run via CLI to check for compile errors before using VS C
 
 ```bash
 # e.g. build Android
-dotnet build -f:net8.0-android
+dotnet build -f:net9.0-android
 
 # or run
-dotnet run -f:net8.0-android
+dotnet run -f:net9.0-android
 
 # similarly for iOS (on macOS)
-dotnet build -f:net8.0-ios
+dotnet build -f:net9.0-ios
 ```
 
 If build fails, examine the error messages, ensure workloads and SDKs are installed and paths configured.
@@ -155,11 +163,11 @@ If build fails, examine the error messages, ensure workloads and SDKs are instal
 
 ## 8. Troubleshooting Tips & Notes
 
-- Make sure your **.NET MAUI extension** is up to date. ([marketplace.visualstudio.com](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-maui&utm_source=chatgpt.com))  
+- Make sure your **.NET MAUI extension** is up to date. ([marketplace.visualstudio.com](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-maui))  
 - If you see errors about missing Android SDK / Java, double-check your environment variable paths.  
 - Use VS Code’s **Output** pane / **Problems** tab to inspect build issues.  
 - On macOS, if iOS build fails, ensure Xcode installation and device/simulator support are correct.  
-- Hot reload and rapid iteration: the extension supports hot reload (enable in settings) for changes without full redeploy. ([marketplace.visualstudio.com](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-maui&utm_source=chatgpt.com))  
+- Hot reload and rapid iteration: the extension supports hot reload (enable in settings) for changes without full redeploy. ([marketplace.visualstudio.com](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-maui))  
 - If targeting multiple platforms in the same project, ensure all the workloads are installed.
 
 ---


### PR DESCRIPTION
- Update target frameworks from net8.0 to net9.0 (android/ios) to match DeviceFX.NfcApp.csproj
- Add global.json SDK version note (9.0.304) to Section 1
- List all three solution files in Section 2
- Format InstallAndroidDependencies command with proper line continuations
- Remove tracking parameters from all links

Fixes #4