### PR TITLE
Closes #6

### DIFF
--- a/src/DeviceFX.NfcApp/Model/Dto/WebexLicenses.cs
+++ b/src/DeviceFX.NfcApp/Model/Dto/WebexLicenses.cs
@@ -9,13 +9,6 @@ public class WebexLicenseDto
 {
     public string id { get; set; }
     public string name { get; set; }
-    public int totalUnits { get; set; }
-    public int consumedUnits { get; set; }
-    public int consumedByUsers { get; set; }
-    public int consumedByWorkspaces { get; set; }
-    public string subscriptionId { get; set; }
-    public string siteUrl { get; set; }
-    public string siteType { get; set; }
 }
 
 


### PR DESCRIPTION
Remove unused properties from WebexLicenses class to streamline data model, customer confirmed that some records have consumedByUsers & consumedByWorkspaces set to null instead of zero.